### PR TITLE
Align maf_pyspark with DBImport API updates

### DIFF
--- a/utils/maf_pyspark.py
+++ b/utils/maf_pyspark.py
@@ -520,7 +520,7 @@ def parallelGen(config_file, inputFileList, outputDir, combinedOutputFile):
     callset_mapping["callsets"].update(maf.callset_mapping)
 
     helper.createMappingFiles(
-        outputDir, combinedOutputFile, callset_mapping, rs.id, config.DB_URI)
+        outputDir, callset_mapping, rs.id, config.DB_URI, combinedOutputFile=combinedOutputFile)
 
 if __name__ == "__main__":
 

--- a/utils/maf_pyspark.py
+++ b/utils/maf_pyspark.py
@@ -275,7 +275,6 @@ def updateIds(keys, callset_mapping, output_file):
 
             CallSet = metadb.registerCallSet(
                 guid=str(uuid.uuid4()),
-                individual_guid=Individual.guid,
                 source_sample_guid=SourceSample.guid,
                 target_sample_guid=TargetSample.guid,
                 workspace=config.TileDBSchema['workspace'],


### PR DESCRIPTION
This PR has a few fixes that align the maf pyspark importer with the API updates for DBImport. There was also a change in a helper function that needed to be reflected in the function call. I've tested this locally and the import process is as expected.

This is ready to be merged upon approval. 
