### PR TITLE
Fix metadb privileges for ga4gh_writer 

### DIFF
--- a/infrastructure/ansible/roles/genomicsdb/tasks/metadb.yml
+++ b/infrastructure/ansible/roles/genomicsdb/tasks/metadb.yml
@@ -25,7 +25,8 @@
     db           : "{{meta_db_name}}"
     grant_option : yes
     privs        : ALL
-    type         : database
+    type         : table
+    obj          : ALL_IN_SCHEMA
   become          : yes
   become_user     : postgres
 


### PR DESCRIPTION
This PR has two fixes:
1. give owner privileges on metadb to ga4gh_writer, previously only the initial creator of the database could dropdb. This is useful incase the import process fails, and the ga4gh_writer user needs to wipe and start over. 
2. grant all privileges to ga4gh_writer on the metadb. This covers the case that metadb has been created and set up via alembic by a user other than ga4gh_writer; this is useful if a previous user has imported data and registered items with metadb, and they are just running the ansible playbook to update everything. 

This is ok to merge after a review. 
