### PR TITLE
Use reference fasta to fetch ref allele instead of reaching out to ensemble

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,5 @@ alembic==0.8.2
 psycopg2==2.6.1
 PyVCF==0.6.8
 pysam==0.9.0
+numpy==1.11.2
+pyfasta==0.5.2

--- a/utils/maf2tile.py
+++ b/utils/maf2tile.py
@@ -88,8 +88,11 @@ if __name__ == "__main__":
         required=False,
         type=str,
         help="Loader JSON to load data into Tile DB.")
+    parser.add_argument('-r', '--reference_fasta', required=True, type=str,
+                        help='reference fasta file to get the reference Allele information')
 
     args = parser.parse_args()
+    helper.verifyFasta(args.reference_fasta)
 
     if args.spark:
         # call spark from within import script
@@ -101,7 +104,8 @@ if __name__ == "__main__":
             "maf_pyspark.py", 
             "-c", args.config, 
             "-d", args.outputdir, 
-            "-o", args.output, 
+            "-o", args.output,
+            "-r", args.reference_fasta, 
             "-i"]
 
         spark_cmd.extend(args.inputs)
@@ -118,7 +122,7 @@ if __name__ == "__main__":
             raise Exception("Error running converter\n\nERROR: \n{}".format(error))
 
     else:
-
+        multiprocess_import.REFERENCE_FASTA = args.reference_fasta
         multiprocess_import.parallelGen(
             args.config,
             args.inputs,

--- a/utils/maf_importer.py
+++ b/utils/maf_importer.py
@@ -40,7 +40,7 @@ from metadb.api import DBQuery
 from utils.configuration import ConfigReader
 
 CSVLine = csvline.CSVLine
-
+REFERENCE_FASTA = None
 
 class MAF(File2Tile):
 
@@ -264,7 +264,7 @@ class MAF(File2Tile):
             end = start
 
             ref = helper.getReference(assembly, chromosome, start,
-                    start)
+                    start, REFERENCE_FASTA)
             self.prev_TileDBValues['REF'] = ref
             index = 0
             for value in self.prev_TileDBValues['ALT']:
@@ -288,7 +288,7 @@ class MAF(File2Tile):
                 end = self.prev_ChromosomePosition[IDX.CHR_END]
 
                 ref = helper.getReference(assembly, chromosome, start,
-                        start)
+                        start, REFERENCE_FASTA)
                 self.prev_TileDBValues['REF'] = ref \
                     + self.prev_TileDBValues['REF']
                 index = 0

--- a/utils/maf_pyspark.py
+++ b/utils/maf_pyspark.py
@@ -56,6 +56,8 @@ class CONST(IDX):
     INDEX = 1
     PLOIDY = 0
     END_IDX = 0
+    
+    REFERENCE_FASTA = None
 
 
 class MAF_Spark:
@@ -587,7 +589,7 @@ def updateRefAltPos(iter):
                 end = start
 
                 newRef = helper.getReference(assembly, chromosome,
-                        start, start)
+                        start, start, CONST.REFERENCE_FASTA)
                 ref = newRef
 
                 index = 0
@@ -604,7 +606,7 @@ def updateRefAltPos(iter):
                 if bFlag:
                     start = start - 1
                     newRef = helper.getReference(assembly, chromosome,
-                            start, start)
+                            start, start, CONST.REFERENCE_FASTA)
                     ref = newRef + ref
                     index = 0
                     for value in alt:
@@ -749,8 +751,11 @@ if __name__ == '__main__':
 
     parser.add_argument('-l', '--loader', required=False, type=str,
                         help='Loader JSON to load data into Tile DB.')
+    parser.add_argument('-r', '--reference_fasta', required=True, type=str,
+                        help='reference fasta file to get the reference Allele information')
 
     args = parser.parse_args()
+    CONST.REFERENCE_FASTA = args.reference_fasta
 
     parallelGen(
         args.config,

--- a/utils/test/test_helper.py
+++ b/utils/test/test_helper.py
@@ -25,7 +25,7 @@ import gzip
 from unittest import TestCase
 import utils.helper as helper
 
-class TestVCFImporter(TestCase):
+class TestReferenceFasta(TestCase):
 
     @classmethod
     def setUpClass(self):
@@ -44,15 +44,20 @@ GANN
     def test_getReference(self):
         fastafile = self.tmpdir.join('test.fasta')
         fastafile.write(self.fasta)
+        assert helper.verifyFasta(str(fastafile)) is None
         assert helper.getReference("GRCh37", "1", 100, 101, str(fastafile)) != ""
         assert helper.getReference("GRCh37", "M", 1, 2, str(fastafile)) == "GA"
-    
     
     def test_getReference_neg(self):
         with pytest.raises(Exception) as exec_info:
             helper.getReference("GRCh37", "1", 100, 101, '/tmp/missing.fasta')
         assert 'is invalid' in str(exec_info.value)
-
+        
+    def test_verifyFasta_neg(self):
+        fastafile = self.tmpdir.join('test_neg.fasta')
+        with pytest.raises(Exception) as exec_info:
+            helper.verifyFasta(str(fastafile))
+        assert 'is invalid' in str(exec_info.value)
 
 def test_printers():
     helper.log("test")

--- a/utils/test/test_helper.py
+++ b/utils/test/test_helper.py
@@ -47,6 +47,7 @@ GANN
         assert helper.verifyFasta(str(fastafile)) is None
         assert helper.getReference("GRCh37", "1", 100, 101, str(fastafile)) != ""
         assert helper.getReference("GRCh37", "M", 1, 2, str(fastafile)) == "GA"
+        assert helper.getReference("GRCh37", "MT", 1, 2, str(fastafile)) == "GA"
     
     def test_getReference_neg(self):
         with pytest.raises(Exception) as exec_info:

--- a/utils/test/test_maf2tile.py
+++ b/utils/test/test_maf2tile.py
@@ -75,6 +75,13 @@ class TestMAF(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
+        self.fasta = """>chr1
+NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNA
+CTGNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
+>chrM
+GANN
+"""
         self.TESTDB_URI = "postgresql+psycopg2://@:5432/mafend2end"
         if not database_exists(self.TESTDB_URI):
             create_database(self.TESTDB_URI)
@@ -230,6 +237,11 @@ class TestMAF(unittest.TestCase):
             fp.write(json.dumps(config_json))
 
         test_output_dir = self.tmpdir.mkdir("output")
+        
+        ref_fasta = self.tmpdir.join('test_ref.fasta')
+        ref_fasta.write(self.fasta)
+        
+        imp.multiprocess_import.REFERENCE_FASTA = str(ref_fasta)
 
         imp.multiprocess_import.poolGenerateCSV((str(test_config), str(
             input_file), str(test_output_dir) + "/" + "out.txt", False))


### PR DESCRIPTION
using pyfasta to read fasta file to fetch the reference allele. I used the reference fasta from UCSC, and noticed that the chromosome (keys in the fasta object) names may vary from fasta to fasta. So folks using this should be weary of it and modify code to adapt to the fasta keys in their reference file.